### PR TITLE
9 apply mixing matrix to paired registered movie

### DIFF
--- a/code/paired_plane_registration.py
+++ b/code/paired_plane_registration.py
@@ -186,11 +186,9 @@ def paired_plane_cached_movie(h5_file: Path,
         # assert that frames and shifts are the same length
         y_shifts = reg_df['y'].values
         x_shifts = reg_df['x'].values
-        run_nonrigid = False
         if non_rigid:
             assert "nonrigid_x" in reg_df.columns
             assert "nonrigid_y" in reg_df.columns
-            run_nonrigid = True
             # from default parameters:
             # TODO: read this from the log file
             Ly = 512
@@ -200,8 +198,6 @@ def paired_plane_cached_movie(h5_file: Path,
             ymax1 = np.vstack(reg_df.nonrigid_y.values)
             xmax1 = np.vstack(reg_df.nonrigid_x.values)
         assert len(data_length) == len(y_shifts) == len(x_shifts)
-        if run_nonrigid:
-            assert len(data_length) == ymax1.shape[0] == xmax1.shape[0]
         for start_frame, end_frame in zip(start_frames, end_frames):
             r_frames = np.zeros_like(f['data'][start_frame:end_frame])
             frame_group = data_length[start_frame:end_frame]
@@ -211,7 +207,7 @@ def paired_plane_cached_movie(h5_file: Path,
             ymax1_group = ymax1[start_frame:end_frame]
             for frame_index, (frame, dy, dx) in enumerate(zip(frame_group, y_shift_group, x_shift_group)):
                 r_frames[frame_index] = shift_frame(frame=frame, dy=dy, dx=dx)
-            if run_nonrigid:
+            if non_rigid:
                 r_frames = nonrigid.transform_data(r_frames, yblock=blocks[0], xblock=blocks[1], nblocks=blocks[2],
                                                 ymax1=ymax1_group, xmax1=xmax1_group, bilinear=True)
                 # uint16 is preferrable, but suite2p default seems like int16, and other files are in int16

--- a/code/run_capsule.py
+++ b/code/run_capsule.py
@@ -95,23 +95,23 @@ def run():
     output_dir = Path("../results/").resolve()
     paired_directories = list(input_dir.glob("*"))
     for i in paired_directories:
-        oeid1_paired_reg_full_fn, oeid2_paired_reg_full_fn = str(i.name).split("_")[0], str(i.name).split("_")[-1]
-        logging.info(f"Processing pairs, Pair_1, {oeid1_paired_reg_full_fn}, Pair_2, {oeid2_paired_reg_full_fn}")
+        oeid1, oeid2 = str(i.name).split("_")[0], str(i.name).split("_")[-1]
+        logging.info(f"Processing pairs, Pair_1, {oeid1}, Pair_2, {oeid2}")
         logging.info(f"Running paired plane registration...")
-        non_rigid = check_non_rigid_registration(i, oeid1_paired_reg_full_fn)
-        oeid1_paired_reg_full_fn_paired_reg = prepare_cached_paired_plane_movies(oeid1_paired_reg_full_fn, oeid2_paired_reg_full_fn, i, non_rigid=non_rigid)
-        oeid2_paired_reg_full_fn_paired_reg = prepare_cached_paired_plane_movies(oeid2_paired_reg_full_fn, oeid1_paired_reg_full_fn, i, non_rigid=non_rigid)
-        results_dir_oeid1_paired_reg_full_fn = output_dir / oeid1_paired_reg_full_fn
-        results_dir_oeid2_paired_reg_full_fn = output_dir / oeid2_paired_reg_full_fn
-        results_dir_oeid1_paired_reg_full_fn.mkdir(exist_ok=True)
-        results_dir_oeid2_paired_reg_full_fn.mkdir(exist_ok=True) 
-        ppr.episodic_mean_fov(oeid1_paired_reg_full_fn_paired_reg, output_dir / oeid1_paired_reg_full_fn)
-        ppr.episodic_mean_fov(oeid2_paired_reg_full_fn_paired_reg, output_dir / oeid2_paired_reg_full_fn)
+        non_rigid = check_non_rigid_registration(i, oeid1)
+        oeid1_paired_reg = prepare_cached_paired_plane_movies(oeid1, oeid2, i, non_rigid=non_rigid)
+        oeid2_paired_reg = prepare_cached_paired_plane_movies(oeid2, oeid1, i, non_rigid=non_rigid)
+        results_dir_oeid1 = output_dir / oeid1
+        results_dir_oeid2 = output_dir / oeid2
+        results_dir_oeid1.mkdir(exist_ok=True)
+        results_dir_oeid2.mkdir(exist_ok=True) 
+        ppr.episodic_mean_fov(oeid1_paired_reg, output_dir / oeid1)
+        ppr.episodic_mean_fov(oeid2_paired_reg, output_dir / oeid2)
         logging.info(f"Creating movie...")
-        decrosstalk_roim(oeid1_paired_reg_full_fn, oeid2_paired_reg_full_fn, i, output_dir)
-        decrosstalk_roim(oeid2_paired_reg_full_fn, oeid1_paired_reg_full_fn, i, output_dir)
-        shutil.rmtree(Path("../scratch/") / f"{oeid1_paired_reg_full_fn}_registered_to_pair.h5")
-        shutil.rmtree(Path("../scratch/") / f"{oeid2_paired_reg_full_fn}_registered_to_pair.h5")
+        decrosstalk_roim(oeid1, oeid2, i, output_dir)
+        decrosstalk_roim(oeid2, oeid1, i, output_dir)
+        shutil.rmtree(Path("../scratch/") / f"{oeid1}_registered_to_pair.h5")
+        shutil.rmtree(Path("../scratch/") / f"{oeid2}_registered_to_pair.h5")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
@jkim0731 
- full paired registered movie is used to generate the decrosstalk movie
- remove the decrosstalk temp file at the end of processing decrosstalk