### PR TITLE
Fix how cached paired planes search for movies.

### DIFF
--- a/code/decrosstalk_roi_image.py
+++ b/code/decrosstalk_roi_image.py
@@ -1,13 +1,17 @@
 from pathlib import Path
 import numpy as np
 import h5py
+import matplotlib
 import matplotlib.pyplot as plt
 from cellpose import models as cp_models
 import skimage
 import pandas as pd
+from typing import Tuple
 
 
-def get_motion_correction_crop_xy_range_from_both_planes(oeid, paired_id, input_dir):
+def get_motion_correction_crop_xy_range_from_both_planes(
+    oeid: int, paired_id: int, input_dir: Path
+) -> Tuple[list, list]:
     """Get x-y ranges to crop motion-correction frame rolling from both planes
 
     TODO: when nonrigid registration parameter setting is done,
@@ -17,6 +21,10 @@ def get_motion_correction_crop_xy_range_from_both_planes(oeid, paired_id, input_
     ----------
     oeid : int
         ophys experiment ID
+    paired_id : int
+        ophys experiment ID of the paired plane
+    input_dir : Path
+        path to input directory
 
     Returns
     -------
@@ -34,7 +42,7 @@ def get_motion_correction_crop_xy_range_from_both_planes(oeid, paired_id, input_
     return xrange, yrange
 
 
-def get_motion_correction_crop_xy_range(oeid, input_dir):
+def get_motion_correction_crop_xy_range(oeid: int, input_dir: Path) -> Tuple[list, list]:
     """Get x-y ranges to crop motion-correction frame rolling
 
     TODO: move to utils
@@ -67,14 +75,14 @@ def get_motion_correction_crop_xy_range(oeid, input_dir):
 
 
 def decrosstalk_roi_image_from_episodic_mean_fov(
-    oeid,
-    paired_reg_fn,
-    input_dir,
-    pixel_size=0.78,
-    grid_interval=0.01,
-    max_grid_val=0.3,
-    return_recon=False,
-):
+    oeid: int,
+    paired_reg_fn: Path,
+    input_dir: Path,
+    pixel_size: float = 0.78,
+    grid_interval: float = 0.01,
+    max_grid_val: float = 0.3,
+    return_recon: float = False,
+) -> Tuple[np.array, list, list, list]:
     """Get alpha and beta values for an experiment based on
     the mutual information of the ROI images from motion corrected episodic mean FOV images
 
@@ -82,7 +90,7 @@ def decrosstalk_roi_image_from_episodic_mean_fov(
     -----------
     oeid : int
         oeid of the signal plane
-    paired_reg_fn : str, Path
+    paired_reg_fn : Path
         path to paired registration file
         TODO: Once paired plane registration pipeline is finalized,
         this parameter can be removed or replaced with paired_oeid
@@ -159,15 +167,15 @@ def decrosstalk_roi_image_from_episodic_mean_fov(
 
 
 def decrosstalk_roi_image_single_pair_from_episodic_mean_fov(
-    oeid,
-    paired_reg_emf_fn,
-    input_dir,
-    start_frame,
-    pix_size,
-    motion_buffer=5,
-    grid_interval=0.01,
-    max_grid_val=0.3,
-):
+    oeid: int,
+    paired_reg_emf_fn: str,
+    input_dir: Path,
+    start_frame: int,
+    pix_size: float,
+    motion_buffer: int = 5,
+    grid_interval: float = 0.01,
+    max_grid_val: float = 0.3,
+) -> Tuple[float, float, list]:
     """Get alpha and beta values for a single pair of mean images
     based on the mean normalized mutual information of the ROI images
 
@@ -270,14 +278,14 @@ def decrosstalk_roi_image_single_pair_from_episodic_mean_fov(
 
 
 def get_signal_paired_top_masks(
-    signal_mean,
-    paired_mean,
-    dendrite_diameter_um=10,
-    pix_size=0.78,
-    nrshiftmax=5,
-    overlap_threshold=0.7,
-    num_top_rois=15,
-):
+    signal_mean: np.array,
+    paired_mean: np.array,
+    dendrite_diameter_um: int = 10,
+    pix_size: float = 0.78,
+    nrshiftmax: int = 5,
+    overlap_threshold: int = 0.7,
+    num_top_rois: int = 15,
+) -> Tuple[np.array, np.array]:
     """Get top masks of 2 paired mean images
     Apply CellPose to get the masks, then filter dendrites and border ROIs
     Then get the top n intensity masks from both planes
@@ -369,13 +377,15 @@ def get_signal_paired_top_masks(
     return signal_top_masks, paired_top_masks
 
 
-def filter_dendrite(masks, dendrite_diameter_pix=10 / 0.78):
+def filter_dendrite(
+    masks: np.array, dendrite_diameter_pix: float = (10 / 0.78)
+) -> np.array:
     """Filter dendrites from masks based on area threshold
 
     Input Parameters
     ----------------
     masks: 2d array, each ROI has a unique integer value
-    dendrite_diameter: int, diameter of dendrite in pix
+    dendrite_diameter_pix: float, diameter of dendrite in pix
 
     Returns
     -------
@@ -394,7 +404,7 @@ def filter_dendrite(masks, dendrite_diameter_pix=10 / 0.78):
     return filtered_mask
 
 
-def filter_border_roi(masks, buffer_pix=5):
+def filter_border_roi(masks: np.array, buffer_pix: int = 5) -> np.array:
     """Filter ROIs that are too close to the border of the FOV
 
     Input Parameters
@@ -422,7 +432,9 @@ def filter_border_roi(masks, buffer_pix=5):
     return filtered_mask
 
 
-def get_top_intensity_mask(img, mask, num_top_rois=15):
+def get_top_intensity_mask(
+    img: np.array, mask: np.array, num_top_rois: int = 15
+) -> np.array:
     """Get top intensity mask
 
     Parameters:
@@ -456,7 +468,7 @@ def get_top_intensity_mask(img, mask, num_top_rois=15):
         return top_mask
 
 
-def get_ranks_roi_inds(img, mask):
+def get_ranks_roi_inds(img: np.array, mask: np.array) -> Tuple[np.array, np.array]:
     """Get ranks and ROI indices based on the intensity of img
     For each ROI ID in the mask
 
@@ -481,7 +493,7 @@ def get_ranks_roi_inds(img, mask):
     return ranks, roi_inds
 
 
-def reorder_mask(mask):
+def reorder_mask(mask: np.array) -> np.array:
     """Reorder mask IDs to have 1 to N IDs
     N = number of ROIs
     Need to run this after filtering dendrites and border ROIs (for convenience)
@@ -503,7 +515,7 @@ def reorder_mask(mask):
     return mask_reordered
 
 
-def get_bounding_box(masks, area_extension_factor=2):
+def get_bounding_box(masks: np.array, area_extension_factor: int = 2) -> np.array:
     """Get bounding box of ROI masks
 
     Parameters:
@@ -549,7 +561,9 @@ def get_bounding_box(masks, area_extension_factor=2):
     return bb_masks
 
 
-def apply_mixing_matrix(alpha, beta, signal_mean, paired_mean):
+def apply_mixing_matrix(
+    alpha: float, beta: float, signal_mean: np.array, paired_mean: np.array
+) -> Tuple[np.array, np.array]:
     """Apply mixing matrix to the mean images to get reconstructed images
 
     Parameters:
@@ -579,7 +593,13 @@ def apply_mixing_matrix(alpha, beta, signal_mean, paired_mean):
     return recon_signal, recon_paired
 
 
-def draw_masks_on_image(img, masks, ax=None, color="r", linewidth=1):
+def draw_masks_on_image(
+    img: np.array,
+    masks: np.array,
+    ax: matplotlib.axes.Axes = None,
+    color: str = "r",
+    linewidth: int = 1,
+) -> Tuple[matplotlib.figure.Figure, matplotlib.axes.Axes]:
     """Draw masks on image
 
     Parameters:

--- a/code/paired_plane_registration.py
+++ b/code/paired_plane_registration.py
@@ -6,7 +6,10 @@ import h5py
 from suite2p.registration import nonrigid
 import shutil
 from aind_ophys_utils.video_utils import encode_video
-import logging
+
+# NOTE: currently this module works in the Session level, someone may want to calculat per
+# experiment
+# TODO: implement per experiment level
 
 
 def get_s2p_motion_transform(csv_path: Path, non_rigid: bool = True) -> pd.DataFrame:
@@ -17,6 +20,8 @@ def get_s2p_motion_transform(csv_path: Path, non_rigid: bool = True) -> pd.DataF
     ----------
     csv_path : Path
         path to suite2p rigid or non-rigid motion transform
+    non_rigid : bool, optional
+        whether to read non-rigid motion transform, by default True
 
     Returns
     -------
@@ -169,7 +174,7 @@ def paired_plane_cached_movie(
     chunk_size: int = 5000,
     non_rigid: bool = True,
     block_size: list = [128, 128],
-):
+) -> Path:
     """Transform frames and save to h5 file
 
     Parameters
@@ -179,19 +184,23 @@ def paired_plane_cached_movie(
     reg_df : pandas.DataFrame
         registration DataFrame (from the csv file) for the pair associated with the non-motion
         corrected movie
-    save_path : Path, optional
-        path to save transformed h5 file, by default None
-    return_rframes : bool, optional
-        return registered frames, by default False
+    tmp_dir : Path, optional
+        temporary directory to save the registered movie, by default Path("../scratch/")
+    chunk_size: int, optional
+        number of frames to process at a time, by default 5000
+    non_rigid: bool, optional
+        whether to use non-rigid registration, by default True
+    block_size: list, optional
+        block size for non-rigid registration, by default [128, 128]
+
     Returns
     -------
     Path to temporary h5 file
     """
 
     with h5py.File(h5_file, "r") as f:
-        logging.info(f"Processing {h5_file}")
+        print(f"~~~~~~~~~H5 File{h5_file}")
         data_length = f["data"].shape[0]
-
         start_frames = np.arange(0, data_length, chunk_size)
         end_frames = np.append(start_frames[1:], data_length)
         # assert that frames and shifts are the same length
@@ -206,9 +215,9 @@ def paired_plane_cached_movie(
             blocks = nonrigid.make_blocks(Ly=Ly, Lx=Lx, block_size=block_size)
             ymax1 = np.vstack(reg_df.nonrigid_y.values)
             xmax1 = np.vstack(reg_df.nonrigid_x.values)
-        logging.info("Data length: %d", data_length)
-        logging.info("Number of shifts: %d", len(y_shifts))
-        logging.info("Number of shifts: %d", len(x_shifts))
+        print(data_length)
+        print(len(y_shifts))
+        print(len(x_shifts))
         assert data_length == len(y_shifts) == len(x_shifts)
         for start_frame, end_frame in zip(start_frames, end_frames):
             r_frames = np.zeros_like(f["data"][start_frame:end_frame], dtype=np.int16)
@@ -231,12 +240,12 @@ def paired_plane_cached_movie(
                     xmax1=xmax1_group,
                     bilinear=True,
                 )
-            # uint16 is preferrable, but suite2p default seems like int16, and other files are
-            # in int16
-            # Suite2p codes also need to be changed to work with uint16 (e.g., using
-            # nonrigid_uint16 branch)
-            # njit pre-defined data type
-            # TODO: change all processing into uint16 in the future
+                # uint16 is preferrable, but suite2p default seems like int16, and other files are
+                # in int16
+                # Suite2p codes also need to be changed to work with uint16 (e.g., using
+                # nonrigid_uint16 branch)
+                # njit pre-defined data type
+                # TODO: change all processing into uint16 in the future
 
             # save r_frames
             temp_path = tmp_dir / f'{h5_file.name.split(".")[0]}_registered_to_pair.h5'
@@ -294,6 +303,18 @@ def shift_frame(frame: np.ndarray, dy: int, dx: int) -> np.ndarray:
 
 
 def fig_paired_planes_registered_projections(projections_dict: dict):
+    """
+    Plot all registered projections for paired planes
+    
+    Parameters
+    ----------
+    projections_dict : dict
+        dictionary containing all registered projections for paired planes
+        
+    Returns
+    -------
+    None
+    """
     # get 99 percentile of all images to set vmax
     images = [v for k, v in projections_dict.items()]
     max_val = np.percentile(np.concatenate(images), 99.9)
@@ -346,6 +367,18 @@ def fig_paired_planes_registered_projections(projections_dict: dict):
 
 
 def histogram_shifts(expt1_shifts, expt2_shifts):
+    """Plot histograms of shifts for each plane
+    Parameters
+    ----------
+    expt1_shifts : pd.DataFrame
+        DataFrame containing the shifts for plane 1
+    expt2_shifts : pd.DataFrame
+        DataFrame containing the shifts for plane 2
+    
+    Returns
+    -------
+    None
+    """
     e1y, e1x = expt1_shifts.y, expt1_shifts.x
     e2y, e2x = expt2_shifts.y, expt2_shifts.x
 

--- a/code/paired_plane_registration.py
+++ b/code/paired_plane_registration.py
@@ -21,7 +21,7 @@ def get_s2p_motion_transform(csv_path: Path, non_rigid: bool = True) -> pd.DataF
     csv_path : Path
         path to suite2p rigid or non-rigid motion transform
     non_rigid : bool, optional
-        whether to read non-rigid motion transform, by default True
+        whether the motion transform is non-rigid, by default True
 
     Returns
     -------
@@ -73,6 +73,8 @@ def generate_mean_episodic_fov_pairings_registered_frames(
         Maximum number of epochs to calculate the mean FOV image for
     num_frames : int
         Number of frames to average to calculate the mean FOV image
+    non_rigid: bool
+        whether the motion transform is non-rigid, by default True
 
     Returns
     -------
@@ -185,12 +187,12 @@ def paired_plane_cached_movie(
         registration DataFrame (from the csv file) for the pair associated with the non-motion
         corrected movie
     tmp_dir : Path, optional
-        temporary directory to save the registered movie, by default Path("../scratch/")
-    chunk_size: int, optional
+        temporary directory to store the registered movie, by default Path("../scratch/")
+    chunk_size : int, optional
         number of frames to process at a time, by default 5000
-    non_rigid: bool, optional
-        whether to use non-rigid registration, by default True
-    block_size: list, optional
+    non_rigid : bool, optional
+        whether the motion transform is non-rigid, by default True
+    block_size : list, optional
         block size for non-rigid registration, by default [128, 128]
 
     Returns
@@ -303,17 +305,18 @@ def shift_frame(frame: np.ndarray, dy: int, dx: int) -> np.ndarray:
 
 
 def fig_paired_planes_registered_projections(projections_dict: dict):
-    """
-    Plot all registered projections for paired planes
-    
+    """Plot registered projections of paired planes
+
     Parameters
     ----------
     projections_dict : dict
-        dictionary containing all registered projections for paired planes
-        
-    Returns
-    -------
-    None
+        dictionary containing the following keys:
+        - plane1_raw
+        - plane1_original_registered
+        - plane1_paired_registered
+        - plane2_raw
+        - plane2_original_registered
+        - plane2_paired_registered
     """
     # get 99 percentile of all images to set vmax
     images = [v for k, v in projections_dict.items()]
@@ -367,17 +370,15 @@ def fig_paired_planes_registered_projections(projections_dict: dict):
 
 
 def histogram_shifts(expt1_shifts, expt2_shifts):
-    """Plot histograms of shifts for each plane
+    """
+    Plot histograms of shifts for each plane
+
     Parameters
     ----------
     expt1_shifts : pd.DataFrame
         DataFrame containing the shifts for plane 1
     expt2_shifts : pd.DataFrame
         DataFrame containing the shifts for plane 2
-    
-    Returns
-    -------
-    None
     """
     e1y, e1x = expt1_shifts.y, expt1_shifts.x
     e2y, e2x = expt2_shifts.y, expt2_shifts.x
@@ -413,6 +414,7 @@ def episodic_mean_fov(
         Number of frames to average to calculate the mean FOV image
     save_webm: bool
         Save webm or not
+
     Returns
     -------
     Path to the mean FOV image h5 file

--- a/code/run_capsule.py
+++ b/code/run_capsule.py
@@ -13,6 +13,7 @@ from datetime import datetime as dt
 import argparse
 import os
 
+
 def write_output_metadata(
     metadata: dict,
     input_fp: Union[str, Path],
@@ -55,7 +56,9 @@ def write_output_metadata(
             ],
         )
     )
-    prev_processing.processing_pipeline.data_processes.append(processing.processing_pipeline.data_processes[0])
+    prev_processing.processing_pipeline.data_processes.append(
+        processing.processing_pipeline.data_processes[0]
+    )
     prev_processing.write_standard_file(output_directory=Path(output_fp).parent)
 
 
@@ -90,12 +93,12 @@ def decrosstalk_roi_movie(
         Path("../scratch").rglob(f"{paired_oeid}_registered_to_pair.h5")
     )
     paired_reg_emf_fn = next(
-        (output_dir.parent.parent.rglob(
-            f"{paired_oeid}_registered_to_pair_episodic_mean_fov.h5"
+        (
+            output_dir.parent.parent.rglob(
+                f"{paired_oeid}_registered_to_pair_episodic_mean_fov.h5"
+            )
         )
     )
-    )
-
 
     ## Just to get alpha and beta for the experiment using the episodic mean fov paired movie
     (
@@ -166,16 +169,17 @@ def decrosstalk_roi_movie(
     )
     return decrosstalk_fn
 
-def debug_movie(h5_file: Path,temp_path: Path = Path("../scratch")) -> Path:
+
+def debug_movie(h5_file: Path, temp_path: Path = Path("../scratch")) -> Path:
     """debug movie for development
-    
+
     Parameters
     ----------
     h5_file: Path
         path to h5 file
     temp_path: Path, optional
         path to temp directory, default is "../scratch"
-    
+
     Returns
     -------
     h5_file: Path
@@ -194,8 +198,14 @@ def debug_movie(h5_file: Path,temp_path: Path = Path("../scratch")) -> Path:
         f.create_dataset("data", data=data)
     return h5_file
 
+
 def prepare_cached_paired_plane_movies(
-    oeid1: str, oeid2: str, input_dir: Path, non_rigid: bool = True, block_size: list=[128, 128], debug: bool = False
+    oeid1: str,
+    oeid2: str,
+    input_dir: Path,
+    non_rigid: bool = True,
+    block_size: list = [128, 128],
+    debug: bool = False,
 ) -> Path:
     """
     Prepare cached paired plane movies
@@ -231,6 +241,8 @@ def prepare_cached_paired_plane_movies(
     return ppr.paired_plane_cached_movie(
         h5_file, transform_df, non_rigid=non_rigid, block_size=block_size
     )
+
+
 def read_json(json_fp: Path) -> dict:
     """
     Get processing json from input directory
@@ -369,8 +381,9 @@ def make_output_dirs(oeid: str, output_dir: Path) -> Path:
     results_dir.mkdir(exist_ok=True)
     return results_dir
 
+
 def get_frame_rate(session_fp: Path) -> float:
-    """ Return frame rate from session.json
+    """Return frame rate from session.json
 
     Parameters
     ----------
@@ -379,7 +392,7 @@ def get_frame_rate(session_fp: Path) -> float:
 
     Returns
     -------
-    frame_rate_hz: float    
+    frame_rate_hz: float
         Frame rate of time series
     """
     session_data = read_json(session_fp)
@@ -392,6 +405,7 @@ def get_frame_rate(session_fp: Path) -> float:
     if isinstance(frame_rate_hz, str):
         frame_rate_hz = float(frame_rate_hz)
     return frame_rate_hz
+
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()

--- a/code/run_capsule.py
+++ b/code/run_capsule.py
@@ -190,13 +190,12 @@ def prepare_cached_paired_plane_movies(
     h5_file: Path
         path to cached paired plane movie
     """
-    h5_file = input_dir / "motion_correction" / f"{oeid1}.h5"
-    oeid_mt = (
-        input_dir.parent / oeid2 / "motion_correction" / f"{oeid2}_motion_transform.csv"
-    )
-    if not h5_file.is_file():
-        h5_file = input_dir.parent.parent / f"{oeid1}_registered.h5"
-        print(f"~~~~~~~~~~~~~~~~~~~~~~~{h5_file}")
+    h5_file = next(input_dir.rglob(f"{oeid1}_registered.h5"), "")
+    if not h5_file:
+        raise FileNotFoundError(f"Could not find {oeid1}_registered.h5")
+    oeid_mt = next(input_dir.rglob(f"{oeid2}_motion_transform.csv"), "")
+    if not oeid_mt:
+        raise FileNotFoundError(f"Could not find {oeid2}_motion_transform.csv")
     transform_df = ppr.get_s2p_motion_transform(oeid_mt)
     return ppr.paired_plane_cached_movie(
         h5_file, transform_df, non_rigid=non_rigid, block_size=block_size

--- a/code/run_capsule.py
+++ b/code/run_capsule.py
@@ -13,6 +13,7 @@ from typing import Union
 from datetime import datetime as dt
 import argparse
 import os
+import tempfile
 
 def write_output_metadata(
     metadata: dict,
@@ -35,8 +36,7 @@ def write_output_metadata(
         url to code repository
     """
     original_proc_file = input_fp.parent
-    with open(original_proc_file / "processing.json", "r") as f:
-        proc_data = json.load(f)
+    proc_data = read_json(original_proc_file / "processing.json")
     prev_processing = Processing(**proc_data)
     processing = Processing(
         processing_pipeline=PipelineProcess(
@@ -90,7 +90,7 @@ def decrosstalk_roi_movie(
     logging.info(f"Ophys experiment ID pairs, {oeid}, {paired_oeid}")
     oeid_mt = input_dir / "motion_correction" / f"{oeid}_motion_transform.csv"
     paired_oeid_reg_to_oeid_full_fn = next(
-        Path("../scratch").glob(f"{paired_oeid}_registered_to_pair.h5")
+        Path("../scratch").rglob(f"{paired_oeid}_registered_to_pair.h5")
     )
     paired_reg_emf_fn = next(
         (output_dir.parent.parent / paired_oeid / "decrosstalk").glob(
@@ -167,9 +167,35 @@ def decrosstalk_roi_movie(
     )
     return decrosstalk_fn
 
+def debug_movie(temp_path: Path, h5_file: Path) -> Path:
+    """debug movie for development
+    
+    Parameters
+    ----------
+    temp_path: Path
+    h5_file: Path
+        path to h5 file
+    
+    Returns
+    -------
+    h5_file: Path
+        path to h5 file
+    """
+    session_fp = h5_file.parent / "session.json"
+    if not session_fp.exists():
+        raise FileNotFoundError(f"Could not find {session_fp}")
+    session_data = read_json(session_fp)
+    frame_rate_hz = get_frame_rate(session_data)
+    with h5.File(temp_path / h5_file.basename, "r") as f:
+        frames_6min = int(360 * float(frame_rate_hz))
+        data = f["data"][:frames_6min]
+    with tempfile.NamedTemporaryFile(suffix=".h5", delete=False) as temp:
+        with h5.File(temp.name, "w") as f:
+            f.create_dataset("data", data=data)
+    return Path(temp.name)
 
 def prepare_cached_paired_plane_movies(
-    oeid1: str, oeid2: str, input_dir: Path, non_rigid: bool = True, block_size=[128, 128]
+    oeid1: str, oeid2: str, input_dir: Path, non_rigid: bool = True, block_size=[128, 128], debug: bool = False
 ) -> Path:
     """
     Prepare cached paired plane movies
@@ -184,15 +210,18 @@ def prepare_cached_paired_plane_movies(
         path to input data
     non_rigid: bool
         True if non-rigid registration was run, False otherwise
-
+    debug: bool, optional
+        True if debugging, False otherwise
     Returns
     -------
     h5_file: Path
         path to cached paired plane movie
     """
-    h5_file = next(input_dir.rglob(f"{oeid1}_registered.h5"), "")
+    h5_file = next(input_dir.rglob(f"{oeid1}.h5"), "")
     if not h5_file:
-        raise FileNotFoundError(f"Could not find {oeid1}_registered.h5")
+        raise FileNotFoundError(f"Could not find {oeid1}.h5")
+    if debug:
+        h5_file = debug_movie(input_dir, h5_file)
     oeid_mt = next(input_dir.rglob(f"{oeid2}_motion_transform.csv"), "")
     if not oeid_mt:
         raise FileNotFoundError(f"Could not find {oeid2}_motion_transform.csv")
@@ -202,24 +231,22 @@ def prepare_cached_paired_plane_movies(
     )
 
 
-def get_processing_json(input_dir: Path) -> dict:
+def read_json(json_fp: Path) -> dict:
     """
     Get processing json from input directory
 
     Parameters
     ----------
-    input_dir: Path
-        path to input data
+    json_fp: Path
+        path to json
 
     Returns
     -------
-    pj: dict
+    data: dict
         processing json
     """
-    processing_json = next(input_dir.glob("*/processing.json"))
-    with open(processing_json, "r") as f:
-        pj = json.load(f)
-    return pj
+    with open(json_fp, "r") as f:
+        return json.load(f)
 
 
 def get_block_size(input_dir: Path) -> list:
@@ -235,7 +262,10 @@ def get_block_size(input_dir: Path) -> list:
     block_size: list
         block size of image
     """
-    processing_json = get_processing_json(input_dir)
+    processing_fp = next(input_dir.rglob("processing.json"), "")
+    if not processing_fp:
+        raise FileNotFoundError(f"Could not find processing.json in {input_dir}")
+    processing_json = read_json(processing_fp)
     try:
         block_size = processing_json["processing_pipeline"]["data_processes"][0][
             "parameters"
@@ -260,7 +290,10 @@ def check_non_rigid_registration(input_dir: Path) -> bool:
     bool
         True if non-rigid registration was run, False otherwise
     """
-    processing_json = get_processing_json(input_dir)
+    processing_fp = next(input_dir.rglob("processing.json"), "")
+    if not processing_fp:
+        raise FileNotFoundError(f"Could not find processing.json in {input_dir}")
+    processing_json = read_json(processing_fp)
     try:
         nonrigid = processing_json["processing_pipeline"]["data_processes"][0][
             "parameters"
@@ -334,6 +367,29 @@ def make_output_dirs(oeid: str, output_dir: Path) -> Path:
     results_dir.mkdir(exist_ok=True)
     return results_dir
 
+def get_frame_rate(session_fp: Path) -> float:
+    """ Return frame rate from session.json
+
+    Parameters
+    ----------
+    session_fp: Path
+        Path to session file
+
+    Returns
+    -------
+    frame_rate_hz: float    
+        Frame rate of time series
+    """
+    session_data = read_json(session_fp)
+    frame_rate_hz = None
+    for i in session_data.get("data_streams", ""):
+        frame_rate_hz = [j["frame_rate"] for j in i["ophys_fovs"]]
+        frame_rate_hz = frame_rate_hz[0]
+        if frame_rate_hz:
+            break
+    if isinstance(frame_rate_hz, str):
+        frame_rate_hz = float(frame_rate_hz)
+    return frame_rate_hz
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
@@ -355,12 +411,11 @@ if __name__ == "__main__":
     non_rigid = check_non_rigid_registration(oeid1_input_dir)
     block_size = get_block_size(oeid1_input_dir)
     oeid1_reg_to_oeid2_motion_filepath = prepare_cached_paired_plane_movies(
-        oeid1, oeid2, oeid1_input_dir, non_rigid=non_rigid, block_size=block_size
+        oeid1, oeid2, input_dir, non_rigid=non_rigid, block_size=block_size
     )
     oeid2_reg_to_oeid1_motion_filepath = prepare_cached_paired_plane_movies(
-        oeid2, oeid1, oeid2_input_dir, non_rigid=non_rigid, block_size=block_size
+        oeid2, oeid1, input_dir, non_rigid=non_rigid, block_size=block_size
     )
-    processing_json = get_processing_json(oeid1_input_dir)
     ppr.episodic_mean_fov(
         oeid1_reg_to_oeid2_motion_filepath, oeid1_output_dir, num_frames=num_frames
     )

--- a/code/run_capsule.py
+++ b/code/run_capsule.py
@@ -183,7 +183,8 @@ def debug_movie(temp_path: Path, h5_file: Path) -> Path:
     h5_file: Path
         path to h5 file
     """
-    session_fp = next(h5_file.parent.parent.rglob("session.json"), "")
+    print(f"~~~~~~~~~~~~~~~~~~~~~~{h5_file}")
+    session_fp = next(h5_file.parent.rglob("session.json"), "")
     if not session_fp:
         raise FileNotFoundError(f"Could not find {session_fp}")
     frame_rate_hz = get_frame_rate(session_fp)

--- a/code/run_capsule.py
+++ b/code/run_capsule.py
@@ -166,15 +166,15 @@ def decrosstalk_roi_movie(
     )
     return decrosstalk_fn
 
-def debug_movie(temp_path: Path = Path("../scratch"), h5_file: Path) -> Path:
+def debug_movie(h5_file: Path,temp_path: Path = Path("../scratch")) -> Path:
     """debug movie for development
     
     Parameters
     ----------
-    temp_path: Path
-        path to temp directory
     h5_file: Path
         path to h5 file
+    temp_path: Path, optional
+        path to temp directory, default is "../scratch"
     
     Returns
     -------
@@ -223,7 +223,7 @@ def prepare_cached_paired_plane_movies(
     if not h5_file:
         raise FileNotFoundError(f"Could not find {oeid1}.h5")
     if debug:
-        h5_file = debug_movie(input_dir, h5_file)
+        h5_file = debug_movie(h5_file)
     oeid_mt = next(input_dir.rglob(f"{oeid2}_motion_transform.csv"), "")
     if not oeid_mt:
         raise FileNotFoundError(f"Could not find {oeid2}_motion_transform.csv")


### PR DESCRIPTION
aind-ophys-motion-correction copied the raw h5 file to it's results directory for decrosstalk processing. The pipeline contains a new channel connection from the raw data to decrosstalk so that the file never needs to be copied in the first place. Also added a debug mode. 