### PR TITLE
fix: rename cellpose model environment variable

### DIFF
--- a/code/decrosstalk_roi_image.py
+++ b/code/decrosstalk_roi_image.py
@@ -9,6 +9,12 @@ import pandas as pd
 import skimage
 from cellpose import models as cp_models
 
+from cellpose import utils
+
+def _override_to_fail_download_func(*args, **kwargs):
+    raise RuntimeError("Network access attempted for model download")
+
+utils.download_url_to_file = _override_to_fail_download_func
 
 def get_motion_correction_crop_xy_range_from_both_planes(
     oeid: int, paired_id: int, input_dir: Path

--- a/environment/Dockerfile
+++ b/environment/Dockerfile
@@ -11,7 +11,7 @@ COPY git-askpass /
 ENV PIPELINE_URL=https://codeocean.allenneuraldynamics.org/capsule/6127754/tree
 ENV PIPELINE_VERSION=1.0
 ENV VERSION=5.0
-ENV CELLPOSE_LOCAL_MODELS_PATHS=/root/capsule
+ENV CELLPOSE_LOCAL_MODELS_PATH=/root/capsule
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \


### PR DESCRIPTION
Typo in local environment variable. Just renamed it to match

https://github.com/MouseLand/cellpose/blob/95f8d9822e14f7fb5b204c8f302f3f5d71a86d3d/cellpose/models.py#L19